### PR TITLE
Implement OpenAI spec streaming API

### DIFF
--- a/internal/llm/interface.go
+++ b/internal/llm/interface.go
@@ -1,5 +1,27 @@
 package llm
 
+// ChatCompletionChunk represents a single chunk of a streamed chat completion
+// response matching the OpenAI specification.
+type ChatCompletionChunk struct {
+	ID      string                 `json:"id"`
+	Object  string                 `json:"object"`
+	Created int64                  `json:"created"`
+	Choices []ChatCompletionChoice `json:"choices"`
+}
+
+// ChatCompletionChoice contains the partial message delta for a streamed chunk.
+type ChatCompletionChoice struct {
+	Delta        Delta   `json:"delta"`
+	Index        int     `json:"index"`
+	FinishReason *string `json:"finish_reason,omitempty"`
+}
+
+// Delta holds the incremental content for the chunk.
+type Delta struct {
+	Content string `json:"content,omitempty"`
+}
+
+// Streamer streams chat completions following the OpenAI streaming format.
 type Streamer interface {
-	Stream(prompt string) (<-chan string, error)
+	Stream(prompt string) (<-chan ChatCompletionChunk, error)
 }

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -1,7 +1,7 @@
 package llm
 
 import (
-	"fmt"
+	"strings"
 	"time"
 )
 
@@ -9,13 +9,38 @@ type OpenAIStreamer struct{}
 
 func NewOpenAIStreamer() Streamer { return &OpenAIStreamer{} }
 
-func (o *OpenAIStreamer) Stream(prompt string) (<-chan string, error) {
-	ch := make(chan string)
+// Stream returns mock chat completion chunks that follow the OpenAI streaming
+// specification. The implementation simply splits the prompt into tokens and
+// emits one token per chunk with slight delays to mimic network latency.
+func (o *OpenAIStreamer) Stream(prompt string) (<-chan ChatCompletionChunk, error) {
+	ch := make(chan ChatCompletionChunk)
 	go func() {
 		defer close(ch)
-		for i := 0; i < 10; i++ {
-			ch <- fmt.Sprintf("token-%d", i)
-			time.Sleep(200 * time.Millisecond)
+		tokens := strings.Fields(prompt)
+		id := "chatcmpl-mock"
+		created := time.Now().Unix()
+		for _, t := range tokens {
+			ch <- ChatCompletionChunk{
+				ID:      id,
+				Object:  "chat.completion.chunk",
+				Created: created,
+				Choices: []ChatCompletionChoice{{
+					Delta: Delta{Content: t + " "},
+					Index: 0,
+				}},
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		stop := "stop"
+		ch <- ChatCompletionChunk{
+			ID:      id,
+			Object:  "chat.completion.chunk",
+			Created: created,
+			Choices: []ChatCompletionChoice{{
+				Delta:        Delta{},
+				Index:        0,
+				FinishReason: &stop,
+			}},
 		}
 	}()
 	return ch, nil


### PR DESCRIPTION
## Summary
- implement OpenAI-compatible streaming handler in Fiber and Gin APIs
- add ChatCompletion chunk types and mock streamer
- update integration test for new streaming format

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*