### PR TITLE
Add context cancellation to streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Introduced context-aware streaming in OpenAI mock streamer and updated HTTP servers accordingly
+
 ## v0.1.0 - 2025-05-17
 - Initial project scaffold with Fiber and Gin servers
 - CLI client

--- a/api/fiber/server.go
+++ b/api/fiber/server.go
@@ -37,7 +37,7 @@ func Start() error {
 			}
 		}
 
-		ch, err := client.Stream(prompt)
+		ch, err := client.Stream(c.Context(), prompt)
 		if err != nil {
 			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 		}

--- a/api/gin/server.go
+++ b/api/gin/server.go
@@ -10,15 +10,15 @@ import (
 )
 
 func Start() error {
-		// set Gin to release mode to disable debug logs and warnings in production
-		gin.SetMode(gin.ReleaseMode)
-		// create a new Gin engine and attach Logger and Recovery middleware
-		r := gin.New()
-		r.Use(gin.Logger(), gin.Recovery())
-		// disable trusting all proxies by default; configure as needed for your deployment
-		if err := r.SetTrustedProxies(nil); err != nil {
-			return err
-		}
+	// set Gin to release mode to disable debug logs and warnings in production
+	gin.SetMode(gin.ReleaseMode)
+	// create a new Gin engine and attach Logger and Recovery middleware
+	r := gin.New()
+	r.Use(gin.Logger(), gin.Recovery())
+	// disable trusting all proxies by default; configure as needed for your deployment
+	if err := r.SetTrustedProxies(nil); err != nil {
+		return err
+	}
 	client := llm.NewOpenAIStreamer()
 
 	r.POST("/v1/chat/completions", func(c *gin.Context) {
@@ -46,7 +46,7 @@ func Start() error {
 			}
 		}
 
-		ch, err := client.Stream(prompt)
+		ch, err := client.Stream(c.Request.Context(), prompt)
 		if err != nil {
 			c.String(http.StatusInternalServerError, err.Error())
 			return

--- a/internal/llm/interface.go
+++ b/internal/llm/interface.go
@@ -1,5 +1,7 @@
 package llm
 
+import "context"
+
 // ChatCompletionChunk represents a single chunk of a streamed chat completion
 // response matching the OpenAI specification.
 type ChatCompletionChunk struct {
@@ -23,5 +25,5 @@ type Delta struct {
 
 // Streamer streams chat completions following the OpenAI streaming format.
 type Streamer interface {
-	Stream(prompt string) (<-chan ChatCompletionChunk, error)
+	Stream(ctx context.Context, prompt string) (<-chan ChatCompletionChunk, error)
 }

--- a/tests/integration/llm_test.go
+++ b/tests/integration/llm_test.go
@@ -4,6 +4,7 @@
 package integration_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 
 func TestOpenAIStreamer(t *testing.T) {
 	streamer := llm.NewOpenAIStreamer()
-	ch, err := streamer.Stream("hello world")
+	ch, err := streamer.Stream(context.Background(), "hello world")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- update Streamer interface to accept context
- respect cancellation in OpenAIStreamer
- pass request contexts from Fiber and Gin servers
- adjust integration test
- document in CHANGELOG

## Testing
- `go test ./...` *(fails: no network access to download toolchain)*