### PR TITLE
Add unified deploy directory

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -12,6 +12,6 @@ jobs:
       - run: echo "$KUBE_CONFIG" | base64 -d > kubeconfig
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-      - run: helm upgrade --install llm charts/llm-fast-wrapper --namespace llm --create-namespace --set llm.backend=openai --set llm.openai.apiKey=${{ secrets.OPENAI_API_KEY }}
+      - run: helm upgrade --install llm deploy/charts/llm-fast-wrapper --namespace llm --create-namespace --set llm.backend=openai --set llm.openai.apiKey=${{ secrets.OPENAI_API_KEY }}
         env:
           KUBECONFIG: kubeconfig

--- a/.gitignore
+++ b/.gitignore
@@ -295,6 +295,8 @@ $RECYCLE.BIN/
 
 # Binaries
 llm-fast-wrapper
+!deploy/charts/llm-fast-wrapper/
+!deploy/charts/llm-fast-wrapper/**
 *.exe
 *.test
 *.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@
   * `telemetry` – OpenTelemetry setup utilities.
   * `recovery` – Disaster recovery and resilience utilities.
 * `docker/` – `docker-compose.yaml` and Prometheus configuration for local infra.
-* `k8s/` and `scripts/` – Helper manifests and scripts for running on Kubernetes via kind.
+* `deploy/` and `scripts/` – Helper manifests and scripts for running on Kubernetes via kind.
 * `tests/` – Ginkgo/Golang unit tests with comprehensive coverage metrics.
 * `Taskfile.yaml` – Defines commands for development, testing, and infrastructure.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Embedding service with optional pgvector storage and in-memory cache
 - Prometheus metrics, Jaeger tracing and Zap structured logging
 - Docker Compose environment with PostgreSQL and Splunk for local testing
-- Kubernetes manifests and Helm chart for cluster deployments
+- Kubernetes manifests and Helm chart (under `deploy/`) for cluster deployments
 
 ## Getting Started
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,6 +7,12 @@ includes:
 
 tasks:
   default:
-    desc: "List all services"
+      desc: "List all services"
+      cmds:
+        - task --list
+
+  deploy:
+    desc: "Build Docker image and deploy via Helm"
     cmds:
-      - task --list
+      - docker build -t llm-fast-wrapper:local .
+      - helm upgrade --install llm deploy/charts/llm-fast-wrapper --namespace llm --create-namespace --set llm.backend=openai --set llm.openai.apiKey=$OPENAI_API_KEY

--- a/deploy/argocd-app.yaml
+++ b/deploy/argocd-app.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     repoURL: https://github.com/raja.aiml/llm-fast-wrapper
     targetRevision: main
-    path: charts/llm-fast-wrapper
+    path: deploy/charts/llm-fast-wrapper
   destination:
     server: https://kubernetes.default.svc
     namespace: llm

--- a/deploy/charts/llm-fast-wrapper/Chart.yaml
+++ b/deploy/charts/llm-fast-wrapper/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: llm-fast-wrapper
+version: 0.1.0
+appVersion: "0.1.0"
+description: A Helm chart for llm-fast-wrapper

--- a/deploy/charts/llm-fast-wrapper/templates/_helpers.tpl
+++ b/deploy/charts/llm-fast-wrapper/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "llm-fast-wrapper.name" -}}
+llm-fast-wrapper
+{{- end -}}
+
+{{- define "llm-fast-wrapper.fullname" -}}
+{{ include "llm-fast-wrapper.name" . }}
+{{- end -}}

--- a/deploy/charts/llm-fast-wrapper/templates/deployment.yaml
+++ b/deploy/charts/llm-fast-wrapper/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "llm-fast-wrapper.fullname" . }}
+  labels:
+    app: {{ include "llm-fast-wrapper.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "llm-fast-wrapper.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "llm-fast-wrapper.name" . }}
+    spec:
+      containers:
+        - name: llm-fast-wrapper
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["serve", "--fiber"]
+          ports:
+            - containerPort: 8080

--- a/deploy/charts/llm-fast-wrapper/templates/service.yaml
+++ b/deploy/charts/llm-fast-wrapper/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llm-fast-wrapper.fullname" . }}
+  labels:
+    app: {{ include "llm-fast-wrapper.name" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+  selector:
+    app: {{ include "llm-fast-wrapper.name" . }}

--- a/deploy/charts/llm-fast-wrapper/values.yaml
+++ b/deploy/charts/llm-fast-wrapper/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: ghcr.io/your-org/llm-fast-wrapper
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 8080


### PR DESCRIPTION
## Summary
- move `k8s` to `deploy` and add Helm chart
- update ArgoCD manifest path
- update GitHub workflow to use new chart location
- add deploy task in Taskfile
- document new location and unignore chart files

## Testing
- `go mod tidy` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*