### PR TITLE
Update k3d postgres to pgvector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Introduced context-aware streaming in OpenAI mock streamer and updated HTTP servers accordingly
 - Switched local Kubernetes setup to k3d with bundled Postgres and Argo CD manifests
+- Updated k3d Postgres deployment to use pgvector image
+- Exposed Postgres service on host at `localhost:5432`
 
 ## v0.1.0 - 2025-05-17
 - Initial project scaffold with Fiber and Gin servers

--- a/deploy/postgres.yaml
+++ b/deploy/postgres.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:16
+          image: pgvector/pgvector:pg17
           env:
             - name: POSTGRES_USER
               value: llm
@@ -29,6 +29,19 @@ spec:
               value: llmlogs
           ports:
             - containerPort: 5432
+              hostPort: 5432
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "llm", "-d", "llmlogs"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "llm", "-d", "llmlogs"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: pgdata
               mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
## Summary
- use pgvector container for k3d postgres deployment
- expose postgres through hostPort so it's reachable at `localhost:5432`
- document change in changelog

## Testing
- `go test ./...` *(fails: no route to host)*